### PR TITLE
CA-6459 Compatibilité cartridge ReachFive SFRA / req.httpParameterMap

### DIFF
--- a/cartridges/int_reachfive_sfra/cartridge/controllers/Login.js
+++ b/cartridges/int_reachfive_sfra/cartridge/controllers/Login.js
@@ -21,7 +21,7 @@ server.prepend('Show', function (req, res, next) {
         context.isReachFiveTransitionActive = reachfiveSettings.isReachFiveTransitionActive;
         context.isReachFiveConversionMute = reachFiveHelper.getReachFiveConversionMute();
 
-        if (req.httpParameterMap.isParameterSubmitted('verification_code')) {
+        if (req.querystring.verification_code) {
             context.isReachFivePasswordReset = true;
         }
     }

--- a/cartridges/int_reachfive_sfra/cartridge/controllers/ReachFiveController.js
+++ b/cartridges/int_reachfive_sfra/cartridge/controllers/ReachFiveController.js
@@ -78,8 +78,8 @@ function getStateData(req) {
         action: false,
         handleCustomerRoute: false
     };
-    if (req.httpParameterMap.isParameterSubmitted('state')) {
-        var stateObjStr = dwStringUtils.decodeBase64(req.httpParameterMap.state.value);
+    if (req.querystring.state) {
+        var stateObjStr = dwStringUtils.decodeBase64(req.querystring.state);
         try {
             stateObj = JSON.parse(stateObjStr);
         } catch (err) {
@@ -114,12 +114,12 @@ server.get(
         var ReachfiveSessionModel = require('*/cartridge/models/reachfiveSession');
 
         //  Step 2: Handle the Authorization Response
-        var code = req.httpParameterMap.code.value;
-        var error = req.httpParameterMap.error.value;
+        var code = req.querystring.code;
+        var error = req.querystring.error;
 
         //  session.privacy.TargetLocation = request.httpParameterMap.redirectUrl.value;
         if (error || error === '') {
-            var message = !!req.httpParameterMap.error_description.value ? req.httpParameterMap.error_description.value : '';
+            var message = req.querystring.error_description ? req.querystring.error_description : '';
             LOGGER.warn('access denied: reach5 response: ' + message);
 
             loginFailedNoCode(message, res);


### PR DESCRIPTION
Remplace req.httpParameterMap par req.querystring dans ReachFiveController.js et Login.js pour compatibilité SFRA 5.0.1.